### PR TITLE
fix: filter on project name in CloudWatch event pattern

### DIFF
--- a/src/processbuildevents.py
+++ b/src/processbuildevents.py
@@ -22,9 +22,6 @@ def handler(build_event, context):
     LOG.debug('Received event: %s', build_event)
 
     build = Build(build_event)
-    if build.project_name != config.PROJECT_NAME:
-        LOG.debug('Not our codebuild project')
-        return
 
     if not build.is_pr_build():
         LOG.debug('Not a PR build')

--- a/template.yml
+++ b/template.yml
@@ -114,6 +114,8 @@ Resources:
               'detail-type':
                 - CodeBuild Build State Change
               detail:
+                'project-name':
+                  - !Ref CodeBuildProjectName
                 'build-status':
                   - SUCCEEDED
                   - FAILED

--- a/test/unit/test_processbuildevents.py
+++ b/test/unit/test_processbuildevents.py
@@ -29,16 +29,6 @@ def test_handler(mocker, mock_build, mock_github):
     mock_github.delete_previous_comments.assert_not_called()
 
 
-def test_handler_different_project_name(mocker, mock_build, mock_github):
-    mock_build.project_name = 'different-project'
-
-    processbuildevents.handler(_mock_build_event(), None)
-
-    mock_build.copy_logs.assert_not_called()
-    mock_github.publish_pr_comment.assert_not_called()
-    mock_github.delete_previous_comments.assert_not_called()
-
-
 def test_handler_not_pr_build(mocker, mock_build, mock_github):
     mock_build.is_pr_build.return_value = False
 
@@ -47,6 +37,7 @@ def test_handler_not_pr_build(mocker, mock_build, mock_github):
     mock_build.copy_logs.assert_not_called()
     mock_github.publish_pr_comment.assert_not_called()
     mock_github.delete_previous_comments.assert_not_called()
+
 
 def test_handler_delete_previous_commments(mocker, mock_build, mock_github):
     processbuildevents.config.DELETE_PREVIOUS_COMMENTS = True


### PR DESCRIPTION
This reduces the number of unnecessary Lambda invocations.