### PR TITLE
fix: Could not parse GitHub owner/repo name from AWS CodeBuild project

### DIFF
--- a/src/github_proxy.py
+++ b/src/github_proxy.py
@@ -111,7 +111,7 @@ class GithubProxy:
                 ' parameter to specify a token to use when writing to GitHub.'.format(config.PROJECT_NAME))
 
         github_location = project_details['source']['location']
-        matches = re.search(r'github\.com\/(.+)\/(.+)\.git$', github_location)
+        matches = re.search(r'github\.com\/(.+)\/(.+)$', github_location)
         if not matches:
             raise RuntimeError(
                 'Could not parse GitHub owner/repo name from AWS CodeBuild project {}. location={}'.format(

--- a/test/unit/test_github_proxy.py
+++ b/test/unit/test_github_proxy.py
@@ -6,7 +6,7 @@ import test_constants
 
 GITHUB_OWNER = 'gh-user'
 GITHUB_REPO = 'gh-repo'
-GITHUB_LOCATION = 'https://github.com/{}/{}.git'.format(GITHUB_OWNER, GITHUB_REPO)
+GITHUB_LOCATION = 'https://github.com/{}/{}'.format(GITHUB_OWNER, GITHUB_REPO)
 CODEBUILD_GITHUB_TOKEN = 'shhh!!'
 SECRETS_MANAGER_GITHUB_TOKEN = "don't tell!!"
 BUILD_STATUS = 'SUCCEEDED'


### PR DESCRIPTION
This fixes an error where the Github repo and owner could not be parsed from the Codebuild projects response object.

Error message: `Could not parse GitHub owner/repo name from AWS CodeBuild project XXX. location=XXX`

It appears the format of the URL for the GitHub repo returned by CodeBuild has changed. This PR updates the regular expression used to parse that URL.