### PR TITLE
add support for codebuild github PR refs pattern

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -27,9 +27,14 @@ class Build:
 
     def get_pr_id(self):
         """If this build was for a PR branch, returns the PR ID, otherwise returns None."""
-        matches = re.match(r'^pr\/(\d+)', self._get_build_details().get('sourceVersion', ""))
+        source_version = self._get_build_details().get('sourceVersion', "")
+        matches = re.match(r'^pr\/(\d+)', source_version)
         if not matches:
-            return None
+            # check for refs pattern
+            pattern = r'refs/pull/(\d+)/head'
+            matches = re.search(pattern, source_version)
+            if not matches:
+                return None
         return int(matches.group(1))
 
     @property

--- a/test/unit/test_build.py
+++ b/test/unit/test_build.py
@@ -52,6 +52,12 @@ def test_get_pr_id_is_pr(mocker, mock_codebuild):
     assert build_obj.get_pr_id() == 123
 
 
+def test_get_pr_id_is_pr_refs_pattern(mocker, mock_codebuild):
+    _mock_build_details('refs/pull/123/head^{2adff25fccedf7c08117b3fc93a7eca896c19060}')
+    build_obj = build.Build(_mock_build_event())
+    assert build_obj.get_pr_id() == 123
+
+
 def test_is_pr_build_not_pr(mocker, mock_codebuild):
     _mock_build_details('master')
     build_obj = build.Build(_mock_build_event())


### PR DESCRIPTION
Im from SageMaker Python SDK Team, we had to recently switch the codeebuild PR triggers to
SourceVersion = refs/pull/{pr-number}/head^{full-commit-SHA}) pattern.

To continue to support PR Comments via this fantastic tool, I wish to add support for this pattern.

More Info in: https://docs.aws.amazon.com/codebuild/latest/userguide/sample-source-version.html

Let me know if more details are needed.

